### PR TITLE
Device development

### DIFF
--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -1,5 +1,11 @@
 class AppDelegate
+  attr_reader :window
+
   def application(application, didFinishLaunchingWithOptions:launchOptions)
+    @window = UIWindow.alloc.initWithFrame(UIScreen.mainScreen.bounds)
+    @window.rootViewController = UINavigationController.alloc.initWithRootViewController(MyVC.alloc.init)
+    @window.rootViewController.wantsFullScreenLayout = true
+    @window.makeKeyAndVisible
     true
   end
 end

--- a/app/view_controller.rb
+++ b/app/view_controller.rb
@@ -1,0 +1,3 @@
+class MyVC < UIViewController
+
+end

--- a/lib/mem-watcher/mem-watcher.rb
+++ b/lib/mem-watcher/mem-watcher.rb
@@ -10,16 +10,18 @@ class MemWatcher
     return false unless correct_env?(args)
     if is_device?
       NSLog("Sorry, you can not run mem-watcher on a device.")
-      return false
-    end
+      false
+    else
+      parent_view = args[:parent_view] if args[:parent_view]
+      parent_view ||= UIApplication.sharedApplication.delegate.window if UIApplication.sharedApplication.delegate.respond_to?(:window)
+      parent_view || abort("MemWatcher needs a `parent_view:` view or access to the window in your AppDelegate via a `window` accessor.")
+      parent_view.addSubview label
+      print "Starting MemWatcher..."
+      start_watcher
+      puts "done."
 
-    parent_view = args[:parent_view] if args[:parent_view]
-    parent_view ||= UIApplication.sharedApplication.delegate.window if UIApplication.sharedApplication.delegate.respond_to?(:window)
-    parent_view || abort("MemWatcher needs a `parent_view:` view or access to the window in your AppDelegate via a `window` accessor.")
-    parent_view.addSubview label
-    print "Starting MemWatcher..."
-    start_watcher
-    puts "done."
+      true
+    end
   end
 
   private

--- a/lib/mem-watcher/mem-watcher.rb
+++ b/lib/mem-watcher/mem-watcher.rb
@@ -8,6 +8,11 @@ class MemWatcher
 
   def watch(args={})
     return false unless correct_env?(args)
+    if is_device?
+      NSLog("Sorry, you can not run mem-watcher on a device.")
+      return false
+    end
+
     parent_view = args[:parent_view] if args[:parent_view]
     parent_view ||= UIApplication.sharedApplication.delegate.window if UIApplication.sharedApplication.delegate.respond_to?(:window)
     parent_view || abort("MemWatcher needs a `parent_view:` view or access to the window in your AppDelegate via a `window` accessor.")
@@ -18,6 +23,16 @@ class MemWatcher
   end
 
   private
+
+  def is_device?
+    @_device_state ||= begin
+      if UIDevice.currentDevice.systemVersion.to_i >= 9
+        !!NSBundle.mainBundle.bundlePath.start_with?('/var/')
+      else
+        !!(UIDevice.currentDevice.model =~ /simulator/i).nil?
+      end
+    end
+  end
 
   def correct_env?(args={})
     args[:env] ||= [ "development" ]
@@ -60,4 +75,3 @@ class MemWatcher
   end
 
 end
-

--- a/spec/mem_watcher_spec.rb
+++ b/spec/mem_watcher_spec.rb
@@ -3,15 +3,31 @@ describe MemWatcher do
     MemWatcher.should.respond_to(:watch)
     MemWatcher.new.should.respond_to(:watch)
   end
+
   it "is provided with no warranty, express or implied" do
     MemWatcher.new.should.be.kind_of(MemWatcher)
   end
+
   it "could and probably will break your app in strange and wonderful ways" do
     MemWatcher.new.private_methods.should.include(:cpu_memory)
   end
+
   it "will hopefully still be useful to someone someday" do
     cpu, mem = MemWatcher.new.send(:cpu_memory)
     cpu.to_f.should.be > 0.0
     mem.to_f.should.be > 0.0
   end
+
+  it "shouldn't work on a device" do
+    MemWatcher.watch(env: [ "test" ]).should != false
+
+    class MemWatcher
+      def is_device?
+        true
+      end
+    end
+
+    MemWatcher.watch(env: [ "test" ]).should == false
+  end
+
 end


### PR DESCRIPTION
Closes #2.

Detects if the app is running on a device and outputs some text saying that we aren't going to run mem-watcher.

With tests.
